### PR TITLE
Changes related to Kafka fault tolerance

### DIFF
--- a/cmd/cardinal-evm-rpc/main.go
+++ b/cmd/cardinal-evm-rpc/main.go
@@ -132,7 +132,10 @@ func main() {
 		tm.Register("debug", sm.API())
 	}
 	log.Debug("Starting stream")
-	sm.Start()
+	if err := sm.Start(); err != nil {
+		log.Error("Error starting stream", "error", err)
+		os.Exit(1)
+	}
 	log.Debug("Waiting for stream to be ready")
 	<-sm.Ready()
 	log.Debug("Stream ready")

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/openrelayxyz/cardinal-rpc v0.0.5
 	github.com/openrelayxyz/cardinal-storage v0.0.3
-	github.com/openrelayxyz/cardinal-streams v0.0.8
+	github.com/openrelayxyz/cardinal-streams v0.0.10
 	github.com/openrelayxyz/cardinal-types v0.0.2
 	github.com/openrelayxyz/plugeth-utils v0.0.9
 	github.com/stretchr/testify v1.7.0

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -74,6 +74,7 @@ func InitializeNode(stack core.Node, b restricted.Backend) {
 			*defaultTopic,
 			map[string]string{
 				fmt.Sprintf("c/%x/a/", chainid): *stateTopic,
+				fmt.Sprintf("c/%x/s", chainid): *stateTopic,
 				fmt.Sprintf("c/%x/c/", chainid): *codeTopic,
 				fmt.Sprintf("c/%x/b/[0-9a-z]+/h", chainid): *blockTopic,
 				fmt.Sprintf("c/%x/b/[0-9a-z]+/d", chainid): *blockTopic,

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -262,6 +262,7 @@ func BlockUpdates(block *types.Block, td *big.Int, receipts types.Receipts, dest
 		batches,
 	); err != nil {
 		log.Error("Failed to send block", "block", hash, "err", err)
+		panic(err.Error())
 		return
 	}
 	batchUpdates := make(map[string][]byte)

--- a/streams/consumer.go
+++ b/streams/consumer.go
@@ -23,6 +23,7 @@ func NewStreamManager(brokerURL, defaultTopic string, topics []string, rollback,
 	lastHash, lastNumber, lastWeight, resumption := s.LatestBlock()
 	trackedPrefixes := []*regexp.Regexp{
 		regexp.MustCompile("c/[0-9a-z]+/a/"),
+		regexp.MustCompile("c/[0-9a-z]+/s"),
 		regexp.MustCompile("c/[0-9a-z]+/c/"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/h"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/d"),


### PR DESCRIPTION
* In the plugin, if Kafka writes fail, panic. It is better that
  the master stops progressing if it can't send to Kafka than
  have blocks that get missed in the feed.
* In Cardinal, if there are errors starting the Kafka consumer,
  print them and exit.