### PR TITLE
Reset log level in polygon plugin

### DIFF
--- a/plugins/polygon/main.go
+++ b/plugins/polygon/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/openrelayxyz/plugeth-utils/restricted/rlp"
 	"github.com/openrelayxyz/plugeth-utils/restricted/types"
 	"github.com/openrelayxyz/cardinal-types/hexutil"
+	"time"
+	"strconv"
 )
 
 var (
@@ -19,11 +21,17 @@ var (
 	stack core.Node
 	chainid int64
 	client core.Client
+	targetVerbosity int
 )
 
 func Initialize(ctx core.Context, loader core.PluginLoader, logger core.Logger) {
 	log = logger
 	log.Info("Cardinal EVM polygon plugin initializing")
+	var err error
+	targetVerbosity, err = strconv.Atoi(ctx.String("verbosity"))
+	if err != nil {
+		targetVerbosity = 3
+	}
 }
 
 func InitializeNode(s core.Node, b restricted.Backend) {
@@ -36,6 +44,12 @@ func InitializeNode(s core.Node, b restricted.Backend) {
 	if err != nil {
 		log.Warn("Failed to initialize RPC client, cannot process block")
 	}
+	var x interface{}
+	client.Call(&x, "debug_verbosity", targetVerbosity + 1)
+	time.AfterFunc(30 * time.Second, func() {
+		client.Call(&x, "debug_verbosity", targetVerbosity + 1)
+	})
+	log.Info("Cardinal EVM resetting log level")
 }
 
 func UpdateStreamsSchema(schema map[string]string) {


### PR DESCRIPTION
Bor is doing something weird with respect to log level. It seems to have shifted log levels by one, so that 3 = warning when it says 3 = info. Additionally, it seems to be setting the log level back to 3 regardless of what the flag says.

This update will use the debug_verbosity RPC method to set it to its intended value based on the flag.