### PR TITLE
Feature/check tracked prefixes

### DIFF
--- a/plugins/producer/main.go
+++ b/plugins/producer/main.go
@@ -116,6 +116,7 @@ func InitializeNode(stack core.Node, b restricted.Backend) {
 	schema := map[string]string{
 		fmt.Sprintf("c/%x/a/", chainid): *stateTopic,
 		fmt.Sprintf("c/%x/s", chainid): *stateTopic,
+		fmt.Sprintf("c/%x/f", chainid): *stateTopic,
 		fmt.Sprintf("c/%x/c/", chainid): *codeTopic,
 		fmt.Sprintf("c/%x/b/[0-9a-z]+/h", chainid): *blockTopic,
 		fmt.Sprintf("c/%x/b/[0-9a-z]+/d", chainid): *blockTopic,
@@ -384,6 +385,11 @@ func getUpdates(block *types.Block, td *big.Int, receipts types.Receipts, destru
 	}
 	batchUpdates := map[ctypes.Hash]map[string][]byte{
 		ctypes.BigToHash(block.Number()): make(map[string][]byte),
+	}
+	if storage != nil {
+		updates[fmt.Sprintf("c/%x/f", chainid)] = []byte{1}
+	} else {
+		updates[fmt.Sprintf("c/%x/f", chainid)] = []byte{0}
 	}
 	for addrHash, updates := range storage {
 		for k, v := range updates {

--- a/streams/consumer.go
+++ b/streams/consumer.go
@@ -57,6 +57,7 @@ func NewStreamManager(brokerParams []transports.BrokerParams, reorgThreshold, ch
 	trackedPrefixes := []*regexp.Regexp{
 		regexp.MustCompile("c/[0-9a-z]+/a/"),
 		regexp.MustCompile("c/[0-9a-z]+/s"),
+		regexp.MustCompile("c/[0-9a-z]+/f"),
 		regexp.MustCompile("c/[0-9a-z]+/c/"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/h"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/d"),
@@ -110,13 +111,19 @@ func (m *StreamManager) Start() error {
 	go func() {
 		for {
 			log.Debug("Waiting for message")
+			storageSentinelKey := fmt.Sprintf("c/%x/f", m.chainid)
 			select {
 			case update := <-ch:
 				start := time.Now()
 				added := update.Added()
 				for _, pb := range added {
 					updates := make([]storage.KeyValue, 0, len(pb.Values))
+					completeBlock := false
 					for k, v := range pb.Values {
+						if k == storageSentinelKey {
+							completeBlock = (v[0] == 1)
+							continue
+						}
 						if matchesAny(k, m.trackedPrefixes) {
 							updates = append(updates, storage.KeyValue{Key: []byte(k), Value: v})
 						}
@@ -124,6 +131,10 @@ func (m *StreamManager) Start() error {
 					deletes := make([][]byte, 0, len(pb.Deletes))
 					for k := range pb.Deletes {
 						deletes = append(deletes, []byte(k))
+					}
+					if !completeBlock {
+						log.Warn("Received block without storage sentinel. Dropping.")
+						continue
 					}
 					if err := m.storage.AddBlock(
 						pb.Hash,


### PR DESCRIPTION
This update makes Cardinal-EVM better prepared to work with websocket streams, by only committing required data (not logs and transactions, which are provided in websocket streams) and by tracking whether state changes are included in the block.

This is a sort of soft-fork of the Cardinal-EVM streaming protocol. Because it adds a new key that old replicas will ignore, old replicas can ingest blocks produced by new masters. New replicas will reject blocks produced by old masters, as they will not have the required new key. Thus the update protocol must involve updating masters to the new producer plugin, syncing Cardinal-EVM past the last block produced by old masters, then updating Cardinal-EVM.