### PR TITLE
Feature/websocket init

### DIFF
--- a/cmd/cardinal-evm-rpc/initialization.go
+++ b/cmd/cardinal-evm-rpc/initialization.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"errors"
+	"encoding/json"
+	"net/http"
+	"os"
+	"github.com/openrelayxyz/cardinal-storage/current"
+	// "github.com/openrelayxyz/cardinal-storage/resolver"
+	"github.com/openrelayxyz/cardinal-types/hexutil"
+	"github.com/openrelayxyz/cardinal-types"
+	log "github.com/inconshreveable/log15"
+	"github.com/gorilla/websocket"
+	"github.com/openrelayxyz/cardinal-storage/db/badgerdb"
+	"time"
+)
+
+type rpcResponse struct {
+	Result  json.RawMessage  `json:"result"`
+	JsonRPC string           `json:"jsonrpc"`
+	Id		int                `json:"id"`
+	Params struct{
+		Subscription string    `json:"subscription"`
+		Result json.RawMessage `json:"result"`
+	}
+}
+
+type Record struct {
+	Key        string        `json:"key"`
+	Value      hexutil.Bytes `json:"value"`
+	Hash       types.Hash    `json:"hash"`
+	ParentHash types.Hash    `json:"parentHash"`
+	Number     uint64        `json:"number"`
+	Weight     hexutil.Big   `json:"weight"`
+	Error      string        `json:"error"`
+}
+
+type message struct {
+	Id int          `json:"id"`
+	Method string   `json:"method"`
+	Params []string `json:"params"`
+}
+
+
+func initializer(dbpath, wsURL string) error {
+	db, err := badgerdb.New(os.Args[1])
+	if err != nil {
+		return err
+	}
+	init := current.NewInitializer(db)
+
+	// The post-archive version of the Initializer
+	// init, err := resolver.ResolveInitializer(dbpath, false)
+	// if err != nil {
+	// 	return err
+	// }
+
+	dialer := &websocket.Dialer{
+		EnableCompression: true,
+		Proxy: http.ProxyFromEnvironment,
+		HandshakeTimeout: 45 * time.Second,
+	}
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	message := message{
+		Id: 1,
+		Method: "cardinal_initDB",
+	}
+	msg, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		return err
+	}
+	var res rpcResponse
+	_, resultBytes, err := conn.ReadMessage()
+	if err := json.Unmarshal(resultBytes, &res); err != nil {
+		return err
+	}
+	var subid string
+	if err := json.Unmarshal(res.Result, &subid); err != nil {
+		return err
+	}
+	for counter := 0; err == nil; counter++ {
+		_, resultBytes, err := conn.ReadMessage()
+		if err := json.Unmarshal(resultBytes, &res); err != nil {
+			return err
+		}
+		if res.Params.Subscription != subid {
+			log.Warn("Got unexpected subscription message. Ignoring.", "msg", string(resultBytes))
+			continue
+		}
+		r := Record{}
+		if err = json.Unmarshal(res.Params.Result, &r); err != nil {
+			return err
+		}
+		if r.Error != "" {
+			return errors.New(r.Error)
+		} else if r.Hash != (types.Hash{}) {
+			log.Info("Recording block data", "hash", r.Hash, "num", r.Number)
+			init.SetBlockData(r.Hash, r.ParentHash, r.Number, r.Weight.ToInt())
+		} else {
+			init.AddData([]byte(r.Key), r.Value)
+		}
+		if counter%100000 == 0 {
+			log.Info("Records", "count", counter)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	init.Close()
+	return nil
+}

--- a/cmd/cardinal-evm-rpc/main.go
+++ b/cmd/cardinal-evm-rpc/main.go
@@ -28,6 +28,7 @@ func main() {
 	resumptionTime := flag.Int64("resumption.ts", -1, "Resume from a timestamp instead of the offset committed to the database")
 	blockRollback := flag.Int64("block.rollback", 0, "Rollback to block N before syncing. If N < 0, rolls back from head before starting or syncing.")
 	exitWhenSynced := flag.Bool("exitwhensynced", false, "Automatically shutdown after syncing is complete")
+	initURL := flag.String("init.url", "", "The websockets URL of a master")
 	debug := flag.Bool("debug", false, "Enable debug APIs")
 
 	flag.CommandLine.Parse(os.Args[1:])
@@ -53,6 +54,14 @@ func main() {
 		logLvl = log.LvlInfo
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(logLvl, log.Root().GetHandler()))
+
+	if *initURL != "" {
+		if err := initializer(cfg.DataDir, *initURL); err != nil {
+			log.Crit("Error initializing database", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if len(cfg.Brokers) == 0 {
 		log.Error("No brokers specified")

--- a/plugins/producer/main.go
+++ b/plugins/producer/main.go
@@ -116,6 +116,7 @@ func InitializeNode(stack core.Node, b restricted.Backend) {
 	schema := map[string]string{
 		fmt.Sprintf("c/%x/a/", chainid): *stateTopic,
 		fmt.Sprintf("c/%x/s", chainid): *stateTopic,
+		fmt.Sprintf("c/%x/f", chainid): *stateTopic,
 		fmt.Sprintf("c/%x/c/", chainid): *codeTopic,
 		fmt.Sprintf("c/%x/b/[0-9a-z]+/h", chainid): *blockTopic,
 		fmt.Sprintf("c/%x/b/[0-9a-z]+/d", chainid): *blockTopic,
@@ -384,6 +385,11 @@ func getUpdates(block *types.Block, td *big.Int, receipts types.Receipts, destru
 	}
 	batchUpdates := map[ctypes.Hash]map[string][]byte{
 		ctypes.BigToHash(block.Number()): make(map[string][]byte),
+	}
+	if storage != nil {
+		updates[fmt.Sprintf("c/%x/f", chainid)] = []byte{1}
+	} else {
+		updates[fmt.Sprintf("c/%x/f", chainid)] = []byte{0}
 	}
 	for addrHash, updates := range storage {
 		for k, v := range updates {

--- a/plugins/producer/main.go
+++ b/plugins/producer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 var (
 	log core.Logger
 	ready sync.WaitGroup
+	initLock *sync.RWMutex
 	backend restricted.Backend
 	config *params.ChainConfig
 	chainid int64
@@ -52,12 +54,14 @@ var (
 	codeTopic = Flags.String("cardinal.code.topic", "", "Topic for Cardinal contract code")
 	stateTopic = Flags.String("cardinal.state.topic", "", "Topic for Cardinal state data")
 	startBlockOverride = Flags.Uint64("cardinal.start.block", 0, "The first block to emit")
+	cardinalInit = Flags.Bool("cardinal.init.enabled", false, "Enable cardinal database initialization")
 	reorgThreshold = Flags.Int("cardinal.reorg.threshold", 128, "The number of blocks for clients to support quick reorgs")
 	statsdaddr = Flags.String("cardinal.statsd.addr", "", "UDP address for a statsd endpoint")
 	cloudwatchns = Flags.String("cardinal.cloudwatch.namespace", "", "CloudWatch Namespace for cardinal metrics")
 )
 
 func Initialize(ctx core.Context, loader core.PluginLoader, logger core.Logger) {
+	initLock = &sync.RWMutex{}
 	ready.Add(1)
 	log = logger
 	log.Info("Cardinal EVM plugin initializing")
@@ -407,6 +411,8 @@ func BlockUpdates(block *types.Block, td *big.Int, receipts types.Receipts, dest
 		panic("Unknown broker. Please set --cardinal.broker.url")
 	}
 	ready.Wait()
+	initLock.RLock()
+	defer initLock.RUnlock()
 	if block.NumberU64() < startBlock {
 		log.Debug("Skipping block production", "current", block.NumberU64(), "start", startBlock)
 		return
@@ -471,6 +477,121 @@ func (api *cardinalAPI) ReproduceBlocks(start restricted.BlockNumber, end *restr
 		BlockUpdates(block, td, receipts, destructs, accounts, storage, code)
 	}
 	return true, nil
+}
+
+func (api *cardinalAPI) InitDB(ctx context.Context)(<-chan interface{}, error) {
+	if !*cardinalInit {
+		return nil, fmt.Errorf("cardinal initialization disabled")
+	}
+
+	ch := make(chan interface{}, 100)
+
+	go func() {
+		initLock.Lock()
+		defer initLock.Unlock()
+		log.Info("Starting state dump. Block processing will be paused during this time.")
+		db := backend.ChainDb()
+		snaprootbytes, _ := db.Get(snapRootKey)
+		snaproot := core.BytesToHash(snaprootbytes)
+		headerRLP := backend.CurrentHeader()
+		var header types.Header
+		if err := rlp.DecodeBytes(headerRLP, &header); err != nil {
+			ch <- errMessage{err.Error()}
+			close(ch)
+			return
+		}
+		log.Info("Starting state dump", "headBlock", header.Number.Uint64(), "snaproot", snaproot)
+		for header.Root != snaproot {
+			var err error
+			headerRLP, err = backend.HeaderByNumber(context.Background(), header.Number.Int64() - 1)
+			if err != nil {
+				ch <- errMessage{err.Error()}
+				close(ch)
+				return
+			}
+			header = types.Header{}
+			if err := rlp.DecodeBytes(headerRLP, &header); err != nil {
+				ch <- errMessage{err.Error()}
+				close(ch)
+				return
+			}
+		}
+		blockno := uint64(header.Number.Int64())
+		td := backend.GetTd(context.Background(), header.Hash())
+
+		chainID := backend.ChainConfig().ChainID.Int64()
+		acctIter := db.NewIterator(snapshotAccountPrefix, nil)
+		defer acctIter.Release()
+		ch <- blockMetaOutput{
+			Hash: header.Hash(),
+			ParentHash: header.ParentHash,
+			Number: blockno,
+			Weight: hexutil.Big(*td),
+		}
+		headerBytes, err := rlp.EncodeToBytes(header)
+		if err != nil { panic(err.Error()) }
+		ch <- output{Key: fmt.Sprintf("c/%x/b/%x/h", chainID, header.Hash().Bytes()), Value: hexutil.Bytes(headerBytes)}
+		for acctIter.Next() {
+			if err := ctx.Err(); err != nil {
+				ch <- errMessage{err.Error()}
+				close(ch)
+				return
+			}
+			if len(acctIter.Key()) != 33 { continue }
+			hashedAddress := acctIter.Key()[1:]
+			acctKey := fmt.Sprintf("c/%x/a/%x/d", chainID, hashedAddress)
+			ch <- output{Key: acctKey, Value: hexutil.Bytes(acctIter.Value())}
+			acct, err := fullAccount(acctIter.Value())
+			if err != nil {
+				log.Crit("Error decoding account", "acct", fmt.Sprintf("%#x", hashedAddress), "k", hexutil.Bytes(acctIter.Key()), "rlp", hexutil.Bytes(acctIter.Value()), "err", err)
+				ch <- errMessage{"error decoding account"}
+				close(ch)
+				return
+			}
+			if !bytes.Equal(acct.CodeHash, emptyCode) {
+				v, err := db.Get(append(codePrefix, acct.CodeHash...))
+				if len(v) == 0 {
+					v, err = db.Get(acct.CodeHash)
+				}
+				if err != nil {
+					ch <- errMessage{err.Error()}
+					close(ch)
+					return
+				}
+				codeKey := fmt.Sprintf("c/%x/c/%x", chainID, acct.CodeHash)
+				ch <- output{Key: codeKey, Value: hexutil.Bytes(v)}
+			}
+			if !bytes.Equal(acct.Root, emptyRoot) {
+				count := 0
+				slotIter := db.NewIterator(append(snapshotStoragePrefix, hashedAddress...), nil)
+				for slotIter.Next() {
+					if err := ctx.Err(); err != nil {
+						ch <- errMessage{err.Error()}
+						close(ch)
+						return
+					}
+					count++
+					if len(slotIter.Key()) != 65 { continue }
+					slot := slotIter.Key()[33:]
+					slotKey := fmt.Sprintf("c/%x/a/%x/s/%x", chainID, hashedAddress, slot)
+					ch <- output{Key: slotKey, Value: hexutil.Bytes(slotIter.Value())}
+				}
+				if err := slotIter.Error(); err != nil {
+					ch <- errMessage{err.Error()}
+					close(ch)
+					return
+				}
+				slotIter.Release()
+				if count == 0 { log.Warn("Found 0 slots for non-empty account")}
+			}
+		}
+		if err := acctIter.Error(); err != nil {
+			ch <- errMessage{err.Error()}
+		}
+		close(ch)
+		return
+	}()
+	return ch, nil
 }
 
 func GetAPIs(stack core.Node, backend restricted.Backend) []core.API {

--- a/plugins/producer/statedump.go
+++ b/plugins/producer/statedump.go
@@ -22,6 +22,10 @@ var (
 	codePrefix            = []byte("c")
 )
 
+type errMessage struct {
+	Error string `json:"error"`
+}
+
 type output struct{
 	Key string `json:"key"`
 	Value hexutil.Bytes `json:"value"`

--- a/streams/consumer.go
+++ b/streams/consumer.go
@@ -57,6 +57,7 @@ func NewStreamManager(brokerParams []transports.BrokerParams, reorgThreshold, ch
 	trackedPrefixes := []*regexp.Regexp{
 		regexp.MustCompile("c/[0-9a-z]+/a/"),
 		regexp.MustCompile("c/[0-9a-z]+/s"),
+		regexp.MustCompile("c/[0-9a-z]+/f"),
 		regexp.MustCompile("c/[0-9a-z]+/c/"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/h"),
 		regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/d"),
@@ -110,13 +111,19 @@ func (m *StreamManager) Start() error {
 	go func() {
 		for {
 			log.Debug("Waiting for message")
+			storageSentinelKey := fmt.Sprintf("c/%x/f", m.chainid)
 			select {
 			case update := <-ch:
 				start := time.Now()
 				added := update.Added()
 				for _, pb := range added {
 					updates := make([]storage.KeyValue, 0, len(pb.Values))
+					completeBlock := false
 					for k, v := range pb.Values {
+						if k == storageSentinelKey {
+							completeBlock = (v[0] == 1)
+							continue
+						}
 						if matchesAny(k, m.trackedPrefixes) {
 							updates = append(updates, storage.KeyValue{Key: []byte(k), Value: v})
 						}
@@ -124,6 +131,10 @@ func (m *StreamManager) Start() error {
 					deletes := make([][]byte, 0, len(pb.Deletes))
 					for k := range pb.Deletes {
 						deletes = append(deletes, []byte(k))
+					}
+					if !completeBlock {
+						log.Warn("Received block without storage sentinel. Dropping.")
+						continue
 					}
 					if err := m.storage.AddBlock(
 						pb.Hash,


### PR DESCRIPTION
Historically, Cardinal has had a tedious multi-step process for
exporting data from Geth and importing it into a Cardinal database.
This has gotten us by, and despite the tedium actually has some benefits
(eg. visibility into the ETL process, ability to change things on
the fly), but is not something the average open-source user of Cardinal
will need. To simplify, this commit makes it so you can initialize
Cardinal's database over websockets.

To run, start the master with:

```
./geth [OPTIONS] -- --cardinal.init.enabled
```

```
./cardinal-rpc-url --init.url=wss://localhost:8546 cardinal-config.yaml
```

Note that this will cause the master at localhost:8546 to stop processing
blocks while the database is initialized, so you don't want to run with
--cardinal.init.enabled for normal operation.

Right now the process isn't very resilient - if there is a websockets error
the whole process must be restarted. Perhaps that will be addressed in the
future, but as this should be a relatively rare step it's not a high priority.