### PR TITLE
Reset startBlock during reproduceBlocks

### DIFF
--- a/plugins/producer/main.go
+++ b/plugins/producer/main.go
@@ -517,6 +517,8 @@ func (api *cardinalAPI) ReproduceBlocks(start restricted.BlockNumber, end *restr
 	if toBlock < 0 {
 		toBlock = int64(currentBlock)
 	}
+	oldStartBlock := startBlock
+	startBlock = 0
 	for i := fromBlock; i <= toBlock; i++ {
 		block, td, receipts, destructs, accounts, storage, code, err := api.blockUpdatesByNumber(i)
 		if err != nil {
@@ -524,6 +526,7 @@ func (api *cardinalAPI) ReproduceBlocks(start restricted.BlockNumber, end *restr
 		}
 		BlockUpdates(block, td, receipts, destructs, accounts, storage, code)
 	}
+	startBlock = oldStartBlock
 	return true, nil
 }
 


### PR DESCRIPTION
When reproduceBlocks is called, we want to make sure that the startBlock check is not going to prevent the broadcast.