### PR TITLE
Fix string formatting for polygon

### DIFF
--- a/plugins/polygon/main.go
+++ b/plugins/polygon/main.go
@@ -65,9 +65,9 @@ func UpdateStreamsSchema(schema map[string]string) {
 	if cid == "" {
 		panic("Error finding chainid in schema")
 	}
-	schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/br/", cid)] = schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/r/", cid)]
-	schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/bl/", cid)] = schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/l/", cid)]
-	schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/bs", cid)] = schema[fmt.Sprintf("c/%x/b/[0-9a-z]+/h", cid)]
+	schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/br/", cid)] = schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/r/", cid)]
+	schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/bl/", cid)] = schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/l/", cid)]
+	schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/bs", cid)] = schema[fmt.Sprintf("c/%v/b/[0-9a-z]+/h", cid)]
 }
 
 func CardinalAddBlockHook(number int64, hash, parent ctypes.Hash, weight *big.Int, updates map[string][]byte, deletes map[string]struct{}) {


### PR DESCRIPTION
Since we got the chainid by pulling it from the schema, it will already be hex encoded, so using %x would double hex encoded it. We want %v to just pass the string through.