### PR TITLE
Have Cardinal EVM recognize already known transactions

### DIFF
--- a/api/eth.go
+++ b/api/eth.go
@@ -37,6 +37,7 @@ import (
 	ctypes "github.com/openrelayxyz/cardinal-types"
 	"github.com/openrelayxyz/cardinal-types/hexutil"
 	log "github.com/inconshreveable/log15"
+	"github.com/hashicorp/golang-lru"
 )
 
 type RPCGasLimit func(*types.Header) uint64
@@ -594,10 +595,12 @@ type TransactionEmitter interface {
 type PublicTransactionPoolAPI struct {
 	emitter TransactionEmitter
 	evmmgr  *vm.EVMManager
+	sentCache *lru.Cache
 }
 
 func NewPublicTransactionPoolAPI(emitter TransactionEmitter, evmmgr *vm.EVMManager) *PublicTransactionPoolAPI {
-	return &PublicTransactionPoolAPI{emitter, evmmgr}
+	cache, _ := lru.New(8192)
+	return &PublicTransactionPoolAPI{emitter, evmmgr, cache}
 }
 
 // SendRawTransaction will add the signed transaction to the transaction pool.
@@ -607,7 +610,12 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx *rpc.CallContext, inpu
 	if err := tx.UnmarshalBinary(input); err != nil {
 		return ctypes.Hash{}, err
 	}
-	return tx.Hash(), s.evmmgr.View(func(currentState state.StateDB, header *types.Header, chaincfg *params.ChainConfig) error {
+	hash := tx.Hash()
+	if ok, _ := s.sentCache.ContainsOrAdd(hash, struct{}{}); ok {
+		return ctypes.Hash{}, fmt.Errorf("already known")
+	}
+
+	return hash, s.evmmgr.View(func(currentState state.StateDB, header *types.Header, chaincfg *params.ChainConfig) error {
 		if ctx != nil {
 			if err := ctx.Context().Err(); err != nil {
 				return err

--- a/cmd/tx-relay/main.go
+++ b/cmd/tx-relay/main.go
@@ -39,7 +39,7 @@ func main() {
 		return
 	}
 	defer consumerGroup.Close()
-	cache, _ := lru.New(512)
+	cache, _ := lru.New(8192)
 	for {
 		handler := relayConsumerGroup{
 			url: rpcEndpoint,


### PR DESCRIPTION
Someone has been spamming transactions repeatedly, and with Cardinal EVM only evlauating the eligibility of transactions with respect to confirmed blocks, this creates a lot of traffic on the Kafka topic for transaction relays, as well as a lot of CPU cycles on the master side where they get revalidated.

With this change, Cardinal EVM will remember ~2MB worth of tx hashes and will return "already known" errors for transactions it has broadcast recently.

On the other end of the equation, the tx relay's buffer is increased to reduce the number of transactions being passed on to the master.