### PR TITLE
Have Cardinal EVM recognize already known transactions

### DIFF
--- a/cmd/tx-relay/main.go
+++ b/cmd/tx-relay/main.go
@@ -39,7 +39,7 @@ func main() {
 		return
 	}
 	defer consumerGroup.Close()
-	cache, _ := lru.New(512)
+	cache, _ := lru.New(8192)
 	for {
 		handler := relayConsumerGroup{
 			url: rpcEndpoint,


### PR DESCRIPTION
Someone has been spamming transactions repeatedly, and with Cardinal EVM only evlauating the eligibility of transactions with respect to confirmed blocks, this creates a lot of traffic on the Kafka topic for transaction relays, as well as a lot of CPU cycles on the master side where they get revalidated.

With this change, Cardinal EVM will remember ~2MB worth of tx hashes and will return "already known" errors for transactions it has broadcast recently.

On the other end of the equation, the tx relay's buffer is increased to reduce the number of transactions being passed on to the master.