### PR TITLE
Move "safe" and "finalized" handling to merge plugin

### DIFF
--- a/plugins/merge/main.go
+++ b/plugins/merge/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"math/big"
 	ctypes "github.com/openrelayxyz/cardinal-types"
 	"github.com/openrelayxyz/plugeth-utils/core"
 	"github.com/openrelayxyz/plugeth-utils/restricted"
+	"github.com/openrelayxyz/plugeth-utils/restricted/hexutil"
 	"github.com/openrelayxyz/cardinal-types/metrics"
 )
 
@@ -13,15 +15,39 @@ var (
 	postMerge bool
 	backend restricted.Backend
 	gethWeightGauge = metrics.NewMajorGauge("/geth/weight")
+	stack core.Node
+	chainid int64
 )
+
+type numLookup struct{
+	Number hexutil.Big `json:"number"`
+}
+
+func getSafeFinalized() (*big.Int, *big.Int) {
+	client, err := stack.Attach()
+	if err != nil {
+		log.Warn("Could not stack.Attach()", "err", err)
+		return nil, nil
+	}
+	var snl, fnl numLookup
+	if err := client.Call(&snl, "eth_getBlockByNumber", "safe", false); err != nil {
+		log.Warn("Could not get safe block", "err", err)
+	}
+	if err := client.Call(&fnl, "eth_getBlockByNumber", "finalized", false); err != nil {
+		log.Warn("Could not get finalized block", "err", err)
+	}
+	return snl.Number.ToInt(), fnl.Number.ToInt()
+}
 
 func Initialize(ctx core.Context, loader core.PluginLoader, logger core.Logger) {
 	log = logger
 	log.Info("Cardinal EVM Merge plugin initializing")
 }
 
-func InitializeNode(stack core.Node, b restricted.Backend) {
+func InitializeNode(s core.Node, b restricted.Backend) {
 	backend = b
+	stack = s
+	chainid = b.ChainConfig().ChainID.Int64()
 }
 
 func CardinalAddBlockHook(number int64, hash, parent ctypes.Hash, weight *big.Int, updates map[string][]byte, deletes map[string]struct{}) {
@@ -34,6 +60,13 @@ func CardinalAddBlockHook(number int64, hash, parent ctypes.Hash, weight *big.In
 			gethWeightGauge.Update(new(big.Int).Div(weight, big.NewInt(10000000000000000)).Int64())
 			return
 		}
+	}
+	snum, fnum := getSafeFinalized()
+	if snum != nil {
+		updates[fmt.Sprintf("c/%x/n/safe", chainid)] = snum.Bytes()
+	}
+	if fnum != nil {
+		updates[fmt.Sprintf("c/%x/n/finalized", chainid)] = fnum.Bytes()
 	}
 	// After the merge, the td of a block stops increasing, but certain elements
 	// of  Cardinal still needs a weight for evaluating block ordering. The


### PR DESCRIPTION
Chains like ETC and Polygon don't support safe and finalized, so there's no reason to be running those queries in the core producer plugin when the merge plugin should be present on all the systems with safe / finalized to take into consideration.