### PR TITLE
Fix panic in Transient Storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/holiman/uint256 v1.2.4
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267
-	github.com/openrelayxyz/cardinal-rpc v1.2.0-sf1
+	github.com/openrelayxyz/cardinal-rpc v1.2.0
 	github.com/openrelayxyz/cardinal-storage v1.2.2
 	github.com/openrelayxyz/cardinal-streams v1.4.1
 	github.com/openrelayxyz/cardinal-types v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/openrelayxyz/cardinal-rpc v1.1.0/go.mod h1:UZ5KxcsG51ZMBHvLpaDoIReyHpGfGTkazuSKh8Lx4q8=
-github.com/openrelayxyz/cardinal-rpc v1.2.0-sf1 h1:hWQtpcq8eLuttFX+dG1hNge7qZW2HS0GmyHR4IElaq4=
-github.com/openrelayxyz/cardinal-rpc v1.2.0-sf1/go.mod h1:UZ5KxcsG51ZMBHvLpaDoIReyHpGfGTkazuSKh8Lx4q8=
+github.com/openrelayxyz/cardinal-rpc v1.2.0 h1:nnuqvQpojkYwpwRiAFXmH1lh5mcmrxYDKatjumLXs5A=
+github.com/openrelayxyz/cardinal-rpc v1.2.0/go.mod h1:dvM++vpmtimrfMovrxoFG4n0x54IXFRfPe2w8HmtoJU=
 github.com/openrelayxyz/cardinal-storage v1.2.2 h1:qsG9zPXUX8KjTrRtHOMwnyKxNBrXrj+X2tkyGy/uPLs=
 github.com/openrelayxyz/cardinal-storage v1.2.2/go.mod h1:DYk9/5Pw1AG8rYQsexVsR8vnrMiA8K/pEtmOw3bs8n8=
 github.com/openrelayxyz/cardinal-streams v1.4.1 h1:v0jrxk8iyZpWnccQ+uGRfrktdoTuY/sZMGumLz/x7Ic=

--- a/state/statedb.go
+++ b/state/statedb.go
@@ -86,12 +86,17 @@ func (sdb *stateDB) Copy() StateDB {
 	for addr, sobj := range sdb.state {
 		state[addr] = sobj.copy()
 	}
+	transient := make(map[common.Address]Storage)
+	for addr, sobj := range sdb.transient {
+		transient[addr] = sobj
+	}
 	journal := make([]journalEntry, len(sdb.journal))
 	copy(journal[:], sdb.journal[:])
 	return &stateDB{
 		tx:         sdb.tx,
 		journal:    journal,
 		state:      state,
+		transient:  transient,
 		chainid:    sdb.chainid,
 		refund:     sdb.refund,
 		accessList: sdb.accessList.Copy(),


### PR DESCRIPTION
Copies of the statedb were getting nil transient storage maps, which was causing a panic, which obviously we don't want.

It was compounded by not having upgraded Cardinal RPC to a version which releases the call semaphore on panics. Once we exceed the concurrency limit, servers would lock up entirely