### PR TITLE
Update Cardinal Storage version to support overlay storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267
 	github.com/openrelayxyz/cardinal-rpc v1.2.1
-	github.com/openrelayxyz/cardinal-storage v1.3.0
+	github.com/openrelayxyz/cardinal-storage v1.4.0-overlay1
 	github.com/openrelayxyz/cardinal-streams/v2 v2.0.0
 	github.com/openrelayxyz/cardinal-types v1.1.1
 	github.com/openrelayxyz/plugeth-utils v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOl
 github.com/openrelayxyz/cardinal-rpc v1.1.0/go.mod h1:UZ5KxcsG51ZMBHvLpaDoIReyHpGfGTkazuSKh8Lx4q8=
 github.com/openrelayxyz/cardinal-rpc v1.2.1 h1:3RHYuP1prOHASXCvSMwJ7G2htNBRMSqPrDkdQDzR1dw=
 github.com/openrelayxyz/cardinal-rpc v1.2.1/go.mod h1:dvM++vpmtimrfMovrxoFG4n0x54IXFRfPe2w8HmtoJU=
-github.com/openrelayxyz/cardinal-storage v1.3.0 h1:1OZzxht6he41HYG3To95G10Uuq8aYETCbsraS4aY9sI=
-github.com/openrelayxyz/cardinal-storage v1.3.0/go.mod h1:DYk9/5Pw1AG8rYQsexVsR8vnrMiA8K/pEtmOw3bs8n8=
+github.com/openrelayxyz/cardinal-storage v1.4.0-overlay1 h1:eFUhufEzrwWu5QTJ71ca7Hdp67wsUZg4BU+SGt7wehc=
+github.com/openrelayxyz/cardinal-storage v1.4.0-overlay1/go.mod h1:DYk9/5Pw1AG8rYQsexVsR8vnrMiA8K/pEtmOw3bs8n8=
 github.com/openrelayxyz/cardinal-streams v1.5.1 h1:mcs9CflhFfNh291tBm52HEe117lKWhEwdqr+K2LvKQg=
 github.com/openrelayxyz/cardinal-streams v1.5.1/go.mod h1:c1I8beZ/p0dfSiDbIGSFN+EMgniRLWq6yKJZgo9yqaQ=
 github.com/openrelayxyz/cardinal-streams/v2 v2.0.0 h1:dl25CWj/FLDoKpNNgRxAyi3tFklZt5IO6CMjUUBqg84=


### PR DESCRIPTION
Setting storage to: overlay:///path/to/underlay;/path/to/overlay?cache=1

will use overlay storage for the database. Changes will be written to the overlay. If you specify cache=1, values read from the underlay will be written to the overlay, otherwise they will not.