### PR TITLE
Fixes pertaining to genesis initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267
 	github.com/openrelayxyz/cardinal-rpc v1.2.1
-	github.com/openrelayxyz/cardinal-storage v1.3.0
+	github.com/openrelayxyz/cardinal-storage v1.3.1
 	github.com/openrelayxyz/cardinal-streams/v2 v2.0.0
 	github.com/openrelayxyz/cardinal-types v1.1.1
 	github.com/openrelayxyz/plugeth-utils v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOl
 github.com/openrelayxyz/cardinal-rpc v1.1.0/go.mod h1:UZ5KxcsG51ZMBHvLpaDoIReyHpGfGTkazuSKh8Lx4q8=
 github.com/openrelayxyz/cardinal-rpc v1.2.1 h1:3RHYuP1prOHASXCvSMwJ7G2htNBRMSqPrDkdQDzR1dw=
 github.com/openrelayxyz/cardinal-rpc v1.2.1/go.mod h1:dvM++vpmtimrfMovrxoFG4n0x54IXFRfPe2w8HmtoJU=
-github.com/openrelayxyz/cardinal-storage v1.3.0 h1:1OZzxht6he41HYG3To95G10Uuq8aYETCbsraS4aY9sI=
-github.com/openrelayxyz/cardinal-storage v1.3.0/go.mod h1:DYk9/5Pw1AG8rYQsexVsR8vnrMiA8K/pEtmOw3bs8n8=
+github.com/openrelayxyz/cardinal-storage v1.3.1 h1:9y4lKLG0Y+We2kYEOlHJo/oVV+IjL4g0/AmcmcyVo7U=
+github.com/openrelayxyz/cardinal-storage v1.3.1/go.mod h1:DYk9/5Pw1AG8rYQsexVsR8vnrMiA8K/pEtmOw3bs8n8=
 github.com/openrelayxyz/cardinal-streams v1.5.1 h1:mcs9CflhFfNh291tBm52HEe117lKWhEwdqr+K2LvKQg=
 github.com/openrelayxyz/cardinal-streams v1.5.1/go.mod h1:c1I8beZ/p0dfSiDbIGSFN+EMgniRLWq6yKJZgo9yqaQ=
 github.com/openrelayxyz/cardinal-streams/v2 v2.0.0 h1:dl25CWj/FLDoKpNNgRxAyi3tFklZt5IO6CMjUUBqg84=

--- a/vm/manager.go
+++ b/vm/manager.go
@@ -104,7 +104,7 @@ func (mgr *EVMManager) View(inputs ...interface{}) error {
 		if hash != nil {
 			return *hash
 		}
-		if blockNo != nil && *blockNo > 0 {
+		if blockNo != nil && *blockNo >= 0 {
 			h, _ := mgr.sdbm.Storage.NumberToHash(uint64(*blockNo))
 			hash = &h
 		} else {


### PR DESCRIPTION
The genesis init flags used to require more hand edits to the JSON to get cardinal to accept it. After this, we still need to add the hash and remove the blob schedule, but it's easier to get running.

I also realized that if someone queried the genesis block we were replacing it with the latest block, so I adjusted the if statement that handled that. It was originally intended to catch "latest" and "pending" lookups.